### PR TITLE
bug/PMTS-24-change-dependencies-scope-to-runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,7 @@ dependencies {
     implementation 'io.swagger.core.v3:swagger-annotations:2.1.6'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.4'
     implementation 'commons-codec:commons-codec:1.15'
-
-    compileOnly "io.jsonwebtoken:jjwt-api:0.11.1"
+    implementation "io.jsonwebtoken:jjwt-api:0.11.1"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:0.11.1", "io.jsonwebtoken:jjwt-jackson:0.11.1"
 
     runtimeOnly 'org.postgresql:postgresql'


### PR DESCRIPTION
During runtime (login endpoint) there is an error:
*java.lang.NoClassDefFoundError: org/apache/commons/codec/digest/DigestUtils* 

Fixed by changing apache common dependency scope from **compileOnly** to **implementation**

Change jwt dependency to runtime scope according to [docs](https://github.com/jwtk/jjwt#install-jdk-gradle) as well 
